### PR TITLE
New version 1.1.0

### DIFF
--- a/SOURCES/http-nbd-transfer-1.0.0.tar.gz
+++ b/SOURCES/http-nbd-transfer-1.0.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d09942e8024330e6c7bab1d538c8a141935947867b5bfe2fd0a9d330b5d00e9
-size 25691

--- a/SOURCES/http-nbd-transfer-1.1.0.tar.gz
+++ b/SOURCES/http-nbd-transfer-1.1.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa645f903536ffbfbc6064c59ff1ab3935955fec730e9fd333e0557b653df3bf
+size 26057

--- a/SPECS/http-nbd-transfer.spec
+++ b/SPECS/http-nbd-transfer.spec
@@ -1,5 +1,5 @@
 Name:           http-nbd-transfer
-Version:        1.0.0
+Version:        1.1.0
 Release:        1%{?dist}
 Summary:        Set of tools to transfer NBD requests to a HTTP server
 License:        GPLv3
@@ -33,5 +33,11 @@ make
 %{_libdir}/nbdkit/plugins/nbdkit-multi-http-plugin.so
 
 %changelog
-* Tue May 3 2022 Ronan Abhamon <ronan.abhamon@vates.fr> - 1.0.0-1
+* Mon Jan 09 2023 Ronan Abhamon <ronan.abhamon@vates.fr> - 1.1.0-1
+- HTTP server can reuse binding address now
+- Notify when HTTP server is ready
+- Better error handling and command logs
+- SIGTERM can be safely sent to NBD server
+
+* Tue May 03 2022 Ronan Abhamon <ronan.abhamon@vates.fr> - 1.0.0-1
 - Initial package


### PR DESCRIPTION
- HTTP server can reuse binding address now
- Notify when HTTP server is ready
- Better error handling and command logs
- SIGTERM can be safely sent to NBD server

Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>