### PR TITLE
New version 1.3.0

### DIFF
--- a/SOURCES/http-nbd-transfer-1.2.0.tar.gz
+++ b/SOURCES/http-nbd-transfer-1.2.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c463518a085b10ed29615114ff056d8557f2c7ea24b76a4705c377b8e2ee3c1b
-size 27322

--- a/SOURCES/http-nbd-transfer-1.3.0.tar.gz
+++ b/SOURCES/http-nbd-transfer-1.3.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0037cc5ead9a91effd422f8d6ea298f9cdabcbb23512377f13cc48e91a7c03b
+size 27862

--- a/SPECS/http-nbd-transfer.spec
+++ b/SPECS/http-nbd-transfer.spec
@@ -1,5 +1,5 @@
 Name:           http-nbd-transfer
-Version:        1.2.0
+Version:        1.3.0
 Release:        1%{?dist}
 Summary:        Set of tools to transfer NBD requests to a HTTP server
 License:        GPLv3
@@ -33,6 +33,10 @@ make
 %{_libdir}/nbdkit/plugins/nbdkit-multi-http-plugin.so
 
 %changelog
+* Fri Jul 12 2023 Ronan Abhamon <ronan.abhamon@vates.fr> - 1.3.0-1
+- Handle invalid buffer usage in nbdkit plugin
+- Compatible with both versions of Python: 2 and 3
+
 * Fri Feb 17 2023 Ronan Abhamon <ronan.abhamon@vates.fr> - 1.2.0-1
 - Remove open/close calls to read/write disk
 


### PR DESCRIPTION
- Handle invalid buffer usage in nbdkit plugin
- Compatible with both versions of Python: 2 and 3