### PR TITLE
8.2: New version 1.5.0

### DIFF
--- a/SOURCES/http-nbd-transfer-1.4.0.tar.gz
+++ b/SOURCES/http-nbd-transfer-1.4.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:63bfb29f176ed477730251021d9d68fa16f52085a663c115b13aaa0020a558c1
-size 29167

--- a/SOURCES/http-nbd-transfer-1.5.0.tar.gz
+++ b/SOURCES/http-nbd-transfer-1.5.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8187c1fe53229f2552ef537bf37bb89800c4e404abdf9750cfba1d592d9cb628
+size 29635

--- a/SPECS/http-nbd-transfer.spec
+++ b/SPECS/http-nbd-transfer.spec
@@ -1,5 +1,5 @@
 Name:           http-nbd-transfer
-Version:        1.4.0
+Version:        1.5.0
 Release:        1%{?dist}
 Summary:        Set of tools to transfer NBD requests to a HTTP server
 License:        GPLv3
@@ -36,6 +36,12 @@ PYTHON=%{__python2} %{__python2} ./setup.py install --single-version-externally-
 %{_libdir}/nbdkit/plugins/nbdkit-multi-http-plugin.so
 
 %changelog
+* Tue Nov 19 2024 Ronan Abhamon <ronan.abhamon@vates.tech> - 1.5.0-1
+- Prevent stacktrace during SIGTERM signal and open_device call
+- Robustify nbdkit startup: always wait for sockpath to be created
+- Don't force stdout/stderr flush
+- Fix libs import using underscores instead of dashes
+
 * Wed Jul 31 2024 Ronan Abhamon <ronan.abhamon@vates.tech> - 1.4.0-1
 - Try to open device and start HTTP server before notifying the user
 - Install pyc and pyo files


### PR DESCRIPTION
- Prevent stacktrace during SIGTERM signal and open_device call
- Robustify nbdkit startup: always wait for sockpath to be created
- Don't force stdout/stderr flush
- Fix libs import using underscores instead of dashes
